### PR TITLE
Format to PSR-12, fix for PHP 8.1 and removes redundant code

### DIFF
--- a/CryptAPI/CryptAPI.php
+++ b/CryptAPI/CryptAPI.php
@@ -235,7 +235,7 @@ class CryptAPI
     private static function _request($coin, $endpoint, $params = [], $assoc = false)
     {
         $base_url = Cryptapi::$base_url;
-        $coin     = str_replace('_', '/', $coin);
+        $coin     = str_replace('_', '/', (string) $coin);
 
         if (!empty($params['apikey']) && $endpoint !== 'info') {
             $base_url = CryptAPI::$pro_url;

--- a/CryptAPI/CryptAPI.php
+++ b/CryptAPI/CryptAPI.php
@@ -246,10 +246,9 @@ class CryptAPI
         }
 
         if (!empty($coin)) {
-            $coin = str_replace('_', '/', $coin);
-            $url  = "{$base_url}/{$coin}/{$endpoint}/";
+            $url = "{$base_url}/{$coin}/{$endpoint}/";
         } else {
-            $url  = "{$base_url}/{$endpoint}/";
+            $url = "{$base_url}/{$endpoint}/";
         }
 
         if (!empty($data)) {


### PR DESCRIPTION
Notes about commit:

**Casting coin to empty string in request**
- Makes PHP 8.1 compatible code.
- Passing null to non-nullable internal function parameters is deprecated.

More info: https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation